### PR TITLE
riverpodで状態管理

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,29 +2,58 @@ import 'package:flutter/material.dart';
 import 'package:jwt_auth/home_page.dart';
 import 'package:jwt_auth/login_page.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  // accessTokenを取得する
+final tokenProvider = FutureProvider<String?>((ref) async {
   SharedPreferences prefs = await SharedPreferences.getInstance();
-  var token = prefs.getString('token');
-  runApp(MyApp(token: token));
+  return prefs.getString('token');
+});
+
+void main() {
+  runApp(ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
-  final String? token;// main()で取得したtokenを受け取る
-
-  MyApp({Key? key, this.token}) : super(key: key);
-
+class MyApp extends ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tokenAsyncValue = ref.watch(tokenProvider);
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
+        primarySwatch: Colors.blue,
       ),
-      home: token == null ? const LoginPage() : const HomePage(),// tokenがあればHomePage、なければLoginPageを表示
+      home: tokenAsyncValue.when(
+        data: (token) => token == null ? const LoginPage() : const HomePage(),
+        loading: () => const CircularProgressIndicator(),
+        error: (e, stack) => Text('Error: $e'),
+      ),
     );
   }
 }
+
+/// [StatefulWidget]を使う場合
+// void main() async {
+//   WidgetsFlutterBinding.ensureInitialized();
+//   // accessTokenを取得する
+//   SharedPreferences prefs = await SharedPreferences.getInstance();
+//   var token = prefs.getString('token');
+//   runApp(MyApp(token: token));
+// }
+
+// class MyApp extends StatelessWidget {
+//   final String? token;// main()で取得したtokenを受け取る
+
+//   MyApp({Key? key, this.token}) : super(key: key);
+
+//   @override
+//   Widget build(BuildContext context) {
+//     return MaterialApp(
+//       title: 'Flutter Demo',
+//       theme: ThemeData(
+//         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+//         useMaterial3: true,
+//       ),
+//       home: token == null ? const LoginPage() : const HomePage(),// tokenがあればHomePage、なければLoginPageを表示
+//     );
+//   }
+// }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -86,6 +86,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: b04d4e9435a563673746ccb328d22018c6c9496bb547e11dd56c1b0cc9829fe5
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.10"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -200,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.6"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "6c0a2c30c04206ac05494bcccd8148b76866e1a9248a5a8c84ca7b16fbcb3f6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.10"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -277,6 +293,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
+  flutter_riverpod: ^2.3.10
   http: ^1.1.0
   shared_preferences: ^2.2.1
 


### PR DESCRIPTION
**やったこと**

- flutter_riverpodを導入
- shared_preferencesの状態管理
- アクセストークンを取得できている状態で画面を切り替える

変更後のコード
```dart
import 'package:flutter/material.dart';
import 'package:jwt_auth/home_page.dart';
import 'package:jwt_auth/login_page.dart';
import 'package:shared_preferences/shared_preferences.dart';
import 'package:flutter_riverpod/flutter_riverpod.dart';

final tokenProvider = FutureProvider<String?>((ref) async {
  SharedPreferences prefs = await SharedPreferences.getInstance();
  return prefs.getString('token');
});

void main() {
  runApp(ProviderScope(child: MyApp()));
}

class MyApp extends ConsumerWidget {
  @override
  Widget build(BuildContext context, WidgetRef ref) {
    final tokenAsyncValue = ref.watch(tokenProvider);
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: tokenAsyncValue.when(
        data: (token) => token == null ? const LoginPage() : const HomePage(),
        loading: () => const CircularProgressIndicator(),
        error: (e, stack) => Text('Error: $e'),
      ),
    );
  }
}
```

**変更前のコード**
```dart
/// [StatefulWidget]を使う場合
void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  // accessTokenを取得する
  SharedPreferences prefs = await SharedPreferences.getInstance();
  var token = prefs.getString('token');
  runApp(MyApp(token: token));
}

class MyApp extends StatelessWidget {
  final String? token;// main()で取得したtokenを受け取る

  MyApp({Key? key, this.token}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
        useMaterial3: true,
      ),
      home: token == null ? const LoginPage() : const HomePage(),// tokenがあればHomePage、なければLoginPageを表示
    );
  }
}
```